### PR TITLE
OpenCVDNN moved from ml to dnn

### DIFF
--- a/src/main/java/qupath/tensorflow/stardist/StarDist2D.java
+++ b/src/main/java/qupath/tensorflow/stardist/StarDist2D.java
@@ -77,7 +77,7 @@ import qupath.lib.regions.Padding;
 import qupath.lib.regions.RegionRequest;
 import qupath.lib.roi.GeometryTools;
 import qupath.lib.roi.interfaces.ROI;
-import qupath.opencv.ml.OpenCVDNN;
+import qupath.opencv.dnn.OpenCVDNN;
 import qupath.opencv.ops.ImageDataOp;
 import qupath.opencv.ops.ImageOp;
 import qupath.opencv.ops.ImageOps;
@@ -557,7 +557,7 @@ public class StarDist2D {
 				}
 				if (file.isFile()) {
 					try {
-						var dnn = new OpenCVDNN.Builder(modelPath)
+						var dnn = new OpenCVDNN.Builder(file.toURI())
 								.build();
 						mlOp = ImageOps.ML.dnn(dnn, tileWidth, tileHeight, padding);
 						logger.debug("Loaded model {} with OpenCV DNN", modelPath);


### PR DESCRIPTION
The tensorflow extension would build anymore. I tried to look into it but couldn't fix it. The two proposed changes solved two errors I got about `OpenCVDNN` not being found, and `OpenCVDNN.Builder` wanting an `URI` instead of a `string`. 

However, this is the error I get at the moment:
```
StarDist2D.java:560: error: Builder(URI) has private access in Builder
                                                var dnn = new OpenCVDNN.Builder(file.toURI())
                                                          ^
StarDist2D.java:562: error: method dnn in class ML cannot be applied to given types;
                                                mlOp = ImageOps.ML.dnn(dnn, tileWidth, tileHeight, padding);
                                                                  ^
  required: OpenCVDNN,int,int,Padding,String
  found: OpenCVDNN,int,int,Padding
  reason: actual and formal argument lists differ in length
2 errors
```